### PR TITLE
feat: baseTimeEntity정의 및 folder, image, tag엔터티 정의

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,12 @@ dependencies {
 
 }
 
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.MappedSuperclass")
+}
+
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")

--- a/src/main/kotlin/com/keeply/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/keeply/domain/folder/entity/Folder.kt
@@ -1,0 +1,12 @@
+package com.keeply.domain.folder.entity
+
+import com.keeply.global.entity.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity
+class Folder(
+        @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+        val id: Long? = null,
+        @Column(nullable = false)
+        val name: String
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/keeply/domain/image/entity/Image.kt
+++ b/src/main/kotlin/com/keeply/domain/image/entity/Image.kt
@@ -1,0 +1,16 @@
+package com.keeply.domain.image.entity
+
+import com.keeply.domain.folder.entity.Folder
+import com.keeply.global.entity.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity
+class Image(
+        @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+        val id: Long? = null,
+        @Column(nullable = false)
+        val url: String,
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "folder_id")
+        val folder: Folder
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/keeply/domain/tag/entity/Tag.kt
+++ b/src/main/kotlin/com/keeply/domain/tag/entity/Tag.kt
@@ -1,0 +1,16 @@
+package com.keeply.domain.tag.entity
+
+import com.keeply.domain.image.entity.Image
+import com.keeply.global.entity.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity
+class Tag(
+        @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+        val id: Long? = null,
+        @Column(nullable = false)
+        val name: String,
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "image_id")
+        val image: Image
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/keeply/global/config/JpaConfig.kt
+++ b/src/main/kotlin/com/keeply/global/config/JpaConfig.kt
@@ -1,0 +1,8 @@
+package com.keeply.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig

--- a/src/main/kotlin/com/keeply/global/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/keeply/global/entity/BaseTimeEntity.kt
@@ -1,0 +1,20 @@
+package com.keeply.global.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    var createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null
+} 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 

## 📝작업 내용

- baseTimeEntity정의
- folder, image, tag엔터티 정의

## 💬리뷰 요구사항

> https://ittrue.tistory.com/482 을 기반으로 엔터티를 설계시 data class를 지양
> 
> 코틀린의 data class는 게터와 세터, equals(), hashCode(), toString() copy() 함수 들을 자동으로 생성해 주는 편리한 클래스다. 
> 하지만, data class를 이용하여 엔티티를 정의하게 되면 몇 가지 문제점이 발생할 수 있다.
>
> JPA 엔티티는 setter를 지양하지만, setter의 개방을 막을 수 없는 문제
> 연관관계 매핑으로 인해 발생할 수 있는 toString() 함수의 순환참조 문제
> 동등한 엔티티에 대하여 예상치 못한 결과를 나타낼 수 있는 equals(), hashCode() 함수 문제
> toString(), equals(), hashCode() 함수들을 오버라이딩하여 문제를 해결한다고 하더라도 data class를 사용하는 의미가 사라지게 되며, setter의 개방을 막을 수 없는 문제가 남게 된다.
> 따라서 data class로 엔티티를 정의하지 않는 것이 좋다.

